### PR TITLE
feat (stores): adding views to stores

### DIFF
--- a/src/models/pacakages.store.ts
+++ b/src/models/pacakages.store.ts
@@ -6,8 +6,19 @@ export const PackageStore = types
     packages: types.array(PackageModel),
   })
   .views((store) => ({
-    get entregados() {
+    get deliveredPackages() {
+      // RETORNA LOS PACKAGES QUE FUERON ENTREGADOS
       return store.packages.filter((pack) => pack.status === "ENTREGADO");
+    },
+    get unassignedPackages() {
+      // RETORNA LOS PACKAGES QUE NO ESTAN ASSIGANADOS (status = "unassigned")
+      return store.packages.filter((pack) => pack.status === "unassigned");
+    },
+    get onDeliverPackages() {
+      // RETORNA LOS PACKAGES QUE  ESTAN ASSIGANADOS PERO NO ENTREGADOS
+      return store.packages.filter(
+        (pack) => pack.status === "EN CURSO" || pack.status === "PENDIENTE"
+      );
     },
   }))
   .actions((store) => ({

--- a/src/models/user.store.ts
+++ b/src/models/user.store.ts
@@ -4,13 +4,23 @@ import { UserModel, User } from "../types";
 export const UserStore = types
   .model({
     users: types.array(UserModel),
+    userId: types.maybe(types.string),
   })
   .views((store) => ({
-    get carriersON() {
+    get avaliableCarriers() {
       return store.users.filter(
         (carrier) =>
           carrier.role === "Carrier" && carrier.status === "HABILITADO"
       );
+    },
+    get selectedCarrier() {
+      //RETORNA EL CARRIER SELECCIONADO
+      return store.users.find((user) => user._id === store.userId);
+    },
+    get selectedCarrierPackages() {
+      //RETORNA LOS PACKAGES DE EL CARRIER SELECCIONADO
+      const carrier = store.users.find((user) => user._id === store.userId);
+      return carrier?.packages;
     },
     get carriers() {
       return store.users.filter((user) => user.role === "Carrier");
@@ -23,5 +33,8 @@ export const UserStore = types
     //TODO este any tiene que ser User[]
     setUsers(users: any) {
       store.users.push(...users);
+    },
+    setUserId(userId: string) {
+      store.userId = userId;
     },
   }));


### PR DESCRIPTION
Agregue algunas vistas para los users y los paquetes. Las vistas (VIEWS) sirven para ver paquetes sin entregar, los entregados, o los repartidores disponibles, los paquetes de un repartidor, etc.

USER STORE:
![image](https://github.com/BrianBts/box-client/assets/90634174/b5c68d1f-066e-42a8-afd6-f441a85ce151)


PACKAES STORE:
![image](https://github.com/BrianBts/box-client/assets/90634174/c78c7f47-8c3f-4e31-b753-b0d06f397b9a)


FORMA EN LA QUE SE CONSUMA LA STORE: 
![image](https://github.com/BrianBts/box-client/assets/90634174/ccc2ae87-5fde-424d-a375-a58d493896c7)
