### PR TITLE
fix(Client): name validator regex in input modified & new trim added …

### DIFF
--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -13,10 +13,12 @@ export function RegisterForm() {
 		confirmPassword: '',
 	})
 	const router = useRouter()
+
 	const handleInput = (key: string, value: string) => {
+		const trimmedValue = value.trim()
 		setUserData((prev) => ({
 			...prev,
-			[key]: value,
+			[key]: trimmedValue,
 		}))
 
 		console.log(userData)

--- a/src/hooks/useInput.ts
+++ b/src/hooks/useInput.ts
@@ -29,7 +29,7 @@ export function validator(type: InputValidatorType) {
 	}
 
 	const nameValidator = (value: string) => {
-		const nameRegex = /^[a-zA-Z]+(?: [a-zA-Z]+)*$/
+		const nameRegex = /^\s*[a-zA-Z]+(?: [a-zA-Z]+)*\s*$/
 		if (!value.match(nameRegex)) {
 			return ERROR_MESSAGES.name
 		}


### PR DESCRIPTION
Modificación sobre el nameRegex del input validator, ahora acepta espacios al comienzo y final del input:

![Screen Shot 2023-11-28 at 11 45 03 AM](https://github.com/BrianBts/box-client/assets/137815232/30293c82-3156-4821-9197-1ba6e667ff8b)

Modifiqué también el handleInput, para que haga el trim de los value antes del setUserData:

![Screen Shot 2023-11-28 at 11 45 31 AM](https://github.com/BrianBts/box-client/assets/137815232/a25e92ce-b096-4237-b5cb-affcd84b8c3b)

Demo del register con los espacios en los campos con el validator name, y en consola como llega al userData ya trimmerado:

![Screen Shot 2023-11-28 at 11 59 59 AM](https://github.com/BrianBts/box-client/assets/137815232/a6b76aae-78e1-4e30-9fea-e1048d9e5a1d)

