### PR TITLE
feat(CLIENT): update password page & view added

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { RootStore, RootStoreContext } from 'models/root.store'
 import { ReactNode, useCallback, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+// import { useRouter } from 'next/navigation'
 import { observer } from 'mobx-react-lite'
 import { PackageServices, UserServices } from 'services'
 
@@ -27,15 +27,16 @@ export default observer(function Providers({ children }: ProvidersProps) {
 		store.packages.setPackages(packages)
 	}, [store])
 
-	const router = useRouter()
+	// const router = useRouter()
 
 	const loginValidations = () => {
 		const USER_ID = localStorage.getItem('USER_LOGGED_ID') || ''
 		store.users.setUserLoggedId(USER_ID)
 		store.users.setUserId(USER_ID)
-		if (!store.users.loggedUser) {
-			router.push('/login')
-		}
+		//TODO REVISAR ESTO:
+		// if (!USER_ID || !store.users.loggedUser) {
+		// 	router.push('/login')
+		// }
 	}
 	useEffect(() => {
 		if (!store.users.users.length) {

--- a/src/app/reset-password/[resetToken]/page.tsx
+++ b/src/app/reset-password/[resetToken]/page.tsx
@@ -1,0 +1,26 @@
+'use client'
+import { AppLayout, ArrowLeft, TitleBox } from 'commons'
+import UpdatePasswordView from 'components/UpdatePasswordView'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+
+import React from 'react'
+
+export default function UpdatePasswordPage() {
+	const { resetToken } = useParams()
+
+	return (
+		<AppLayout>
+			<TitleBox
+				className="w-full my-2 pr-6"
+				icon={
+					<Link href={'/login'}>
+						<ArrowLeft />
+					</Link>
+				}>
+				ACTUALIZAR CONSTRASEÑA
+			</TitleBox>
+			<UpdatePasswordView resetToken={resetToken} />
+		</AppLayout>
+	)
+}

--- a/src/components/UpdatePasswordView.tsx
+++ b/src/components/UpdatePasswordView.tsx
@@ -1,0 +1,88 @@
+import { BoxLayout, Button, Title } from 'commons'
+import React, { FormEvent, useCallback, useState } from 'react'
+import { FormInput } from './FormInput'
+import { message } from 'antd'
+import { AuthServices } from 'services'
+import { useRouter } from 'next/navigation'
+
+export default function UpdatePasswordView({ resetToken }: any) {
+	const [userData, setUserData] = useState({
+		password: '',
+		confirmPassword: '',
+	})
+
+	const handleInput = (key: string, value: string) => {
+		setUserData((prev) => ({
+			...prev,
+			[key]: value,
+		}))
+	}
+
+	const router = useRouter()
+
+	const handleUpdate = useCallback(
+		async (event: FormEvent) => {
+			event.preventDefault()
+
+			try {
+				const updateData = {
+					password: userData.password,
+					resetToken,
+				}
+
+				console.log('userData ---> ', updateData)
+
+				if (userData.password !== userData.confirmPassword) {
+					return message.error('Las contraseñas no coinciden')
+				}
+
+				await AuthServices.updatePassword(updateData)
+				message.success('Contraseña actualizada')
+				router.push('/login')
+			} catch (error) {
+				console.error('Error al enviar', error)
+				message.error('Credenciales inválidas')
+			}
+		},
+		[userData.password, userData.confirmPassword]
+	)
+
+	return (
+		<form onSubmit={handleUpdate}>
+			<BoxLayout className="bg-white h-[50%]">
+				<div className="pt-10">
+					<Title>Ingresa tu nueva contraseña</Title>
+				</div>
+				<div className="p-4  flex flex-col items-center gap-5 ">
+					<section className="flex flex-col w-full">
+						<FormInput
+							placeholder="Contraseña"
+							type="password"
+							reference="password"
+							handleInput={handleInput}
+							validation="password"
+							className="my-5"
+						/>
+						<FormInput
+							placeholder="Confirmar Contraseña"
+							type="password"
+							reference="confirmPassword"
+							handleInput={handleInput}
+							validation="password"
+							className="my-5"
+						/>
+					</section>
+					<section className="flex flex-col items-center w-5/6 pt-3 gap-1">
+						<Button
+							disabled={Object.values(userData).some((value) => value === '')}
+							variant="primary"
+							className="w-full mb-2"
+							type="submit">
+							ENVIAR
+						</Button>
+					</section>
+				</div>
+			</BoxLayout>
+		</form>
+	)
+}

--- a/src/services/auth.services.ts
+++ b/src/services/auth.services.ts
@@ -8,7 +8,14 @@ export class AuthServices {
 		return user.data
 	}
 	static async resetPassword(data: any) {
-		const email = await axios.patch(`${BASE_URL}/api/auth/reset-password`, data)
+		const email = await axios.post(`${BASE_URL}/api/auth/reset-password`, data)
 		return email.data
+	}
+	static async updatePassword(data: any) {
+		const updateData = await axios.patch(
+			`${BASE_URL}/api/auth/update-password`,
+			data
+		)
+		return updateData.data
 	}
 }


### PR DESCRIPTION
Nueva ruta y page dentro de reset-password, que toma como params el token del link enviado por mail:
![Screen Shot 2023-12-01 at 15 27 24 PM](https://github.com/BrianBts/box-client/assets/137815232/1d1c26a8-02ed-4f33-aab8-c68d24730b18)

Nuevo componente UpdatePasswordView:
![Screen Shot 2023-12-01 at 15 27 43 PM](https://github.com/BrianBts/box-client/assets/137815232/01029bf7-83ed-4e41-9d32-96cc2697a8f1)

![Screen Shot 2023-12-01 at 15 27 50 PM](https://github.com/BrianBts/box-client/assets/137815232/c7a59f5e-2d01-430a-929d-ee2a8aaf04e4)

Nueva funcion en auth service para el pedido axios con el update de la password:
![Screen Shot 2023-12-01 at 15 28 07 PM](https://github.com/BrianBts/box-client/assets/137815232/9d38e0ab-aa86-44a8-86db-e1df13103e32)
