### PR TITLE
percentage on admin/carrier modified, if carrier have 0 packages, wil…

### DIFF
--- a/src/components/CarrierCard.tsx
+++ b/src/components/CarrierCard.tsx
@@ -21,9 +21,10 @@ export const CarrierCard = observer(function CarrierCard({
 		(pack) => pack.status === 'ENTREGADO'
 	)
 
-	const percentage = Math.floor(
-		(packagesDelivered.length / carrier.packages.length) * 100
-	)
+	const percentage =
+		carrier.packages.length > 0
+			? Math.floor((packagesDelivered.length / carrier.packages.length) * 100)
+			: 0
 
 	const handleSelectCarrier = () => {
 		setUserId(carrier._id)


### PR DESCRIPTION
Si el repartidor no tiene paquetes asignados, ahora el grafico muestra 0% y no NaN.

![Screen Shot 2023-12-04 at 15 04 54 PM](https://github.com/BrianBts/box-client/assets/137815232/2d5b2fa2-a1b9-495c-b05a-d3e4c7cc9b84)
