### PR TITLE
fix (packages store): fix setPackages method

### DIFF
--- a/src/models/packages.store.ts
+++ b/src/models/packages.store.ts
@@ -32,7 +32,7 @@ export const PackageStore = types
 	}))
 	.actions((store) => ({
 		setPackages(packages: Package[]) {
-			store.packages.push(...packages)
+			store.packages.replace(packages)
 		},
 		setPackageId(packId: string) {
 			store.packageId = packId


### PR DESCRIPTION
Se cambio la forma en la que se cargan todos los paquetes en la store, en vez de usar push se usa replace. Esto para que no se repita data.
![image](https://github.com/BrianBts/box-client/assets/90634174/f0541156-b9c1-49fd-bb20-ec9423459503)
